### PR TITLE
Added resiliency to prevent server coma

### DIFF
--- a/src/routes/mapRouter.ts
+++ b/src/routes/mapRouter.ts
@@ -65,7 +65,9 @@ var mime = {
   scd: 'application/octet-stream',
 };
 
-MapRouter.get('/:token/*', async function (req, res) {
+//added next arg to enable err handling within expressJS on file
+//not found async unhandled exceptions.
+MapRouter.get('/:token/*', async function (req, res, next) {
   try {
     var file = decodeURIComponent(
       path.join(dir, req.path.replace(/\/$/, '/index.html'))
@@ -77,13 +79,20 @@ MapRouter.get('/:token/*', async function (req, res) {
 
     const token = req.params.token;
     const pathExt = path.extname(file).slice(1);
-
     // Stream image
     if ((pathExt?.toLowerCase() ?? '') !== 'scd') {
       var type =
         mime[(path.extname(file).slice(1) ?? 'gif') as keyof typeof mime] ||
-        'text/plain';
+            'text/plain';
       var s = fs.createReadStream(file);
+      //we now catch file not found and actually invoke next
+      //per expressJS docs https://expressjs.com/en/guide/error-handling.html
+      //this enables the server process to return its error response instead of
+      //hanging indefinitely and ignoring requests (pending manual restart).
+      s.on('error', err => {
+          console.error('file encountered an error:', err);
+          next(err)
+        });
       s.on('open', function () {
         console.warn('Start downloading file', req.params.token, pathExt);
         res.set('Content-Type', type);

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,6 +32,26 @@ app.use('/maps', MapRouter);
 app.use('/release', ReleaseRouter);
 app.use('/static', StaticRouter);
 
+//add some controlled crashing and see if it helps.
+//Note: this will not save us from async exceptions happening
+//inside expressJS apparently, e.g. with readStream, so
+//we have to handle those separately.  Hopefully this
+//serves as a catch-all to just kill the process and exit.
+//Assuming we have supervisor or some other system process manager
+//watching, we can restart the process automatically if it goes down.
+
+//https://blog.heroku.com/best-practices-nodejs-errors
+process.on('uncaughtException', err => {
+  console.log(`ERROR! Uncaught Exception: ${err.message}`)
+    process.exit(1)
+    })
+
+process.on('unhandledRejection', (reason, promise) => {
+    console.log('Unhandled Rejection at:', promise, 'reason:', reason);
+    // Application specific logging, throwing an error, or other logic here
+
+});
+
 sequelize
   .authenticate()
   .then(() => {


### PR DESCRIPTION
I think these are benign changes.  Behavior before patch would incur an uncaught exception on readStream opening with an unknown/nonexisting file on a GET route.  This would cause the process to hang and ignore additional requests.  This patch adds in error handling on the affected GET route, and routes async error events from the readStream through expressJS error handler to propagate into a generic error response, allowing the server to stay up.  Also added general exception handler to process to kill the process on uncaught exception; should combine this with something like supervisor to have restarts of crashed processes (this way we can actually detect it as opposed to the previous comatose state).